### PR TITLE
Spring Bean 순환 참조(Circular Dependency) 해결 사례

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,11 @@
+# IDE
+.idea/
+*.iml
+.vscode/
+
+# Maven
+target/
+
 # Compiled class file
 *.class
 

--- a/circular-reference-demo/.mvn/wrapper/maven-wrapper.properties
+++ b/circular-reference-demo/.mvn/wrapper/maven-wrapper.properties
@@ -1,0 +1,3 @@
+wrapperVersion=3.3.4
+distributionType=only-script
+distributionUrl=https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.9.9/apache-maven-3.9.9-bin.zip

--- a/circular-reference-demo/mvnw
+++ b/circular-reference-demo/mvnw
@@ -1,0 +1,295 @@
+#!/bin/sh
+# ----------------------------------------------------------------------------
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+# ----------------------------------------------------------------------------
+
+# ----------------------------------------------------------------------------
+# Apache Maven Wrapper startup batch script, version 3.3.4
+#
+# Optional ENV vars
+# -----------------
+#   JAVA_HOME - location of a JDK home dir, required when download maven via java source
+#   MVNW_REPOURL - repo url base for downloading maven distribution
+#   MVNW_USERNAME/MVNW_PASSWORD - user and password for downloading maven
+#   MVNW_VERBOSE - true: enable verbose log; debug: trace the mvnw script; others: silence the output
+# ----------------------------------------------------------------------------
+
+set -euf
+[ "${MVNW_VERBOSE-}" != debug ] || set -x
+
+# OS specific support.
+native_path() { printf %s\\n "$1"; }
+case "$(uname)" in
+CYGWIN* | MINGW*)
+  [ -z "${JAVA_HOME-}" ] || JAVA_HOME="$(cygpath --unix "$JAVA_HOME")"
+  native_path() { cygpath --path --windows "$1"; }
+  ;;
+esac
+
+# set JAVACMD and JAVACCMD
+set_java_home() {
+  # For Cygwin and MinGW, ensure paths are in Unix format before anything is touched
+  if [ -n "${JAVA_HOME-}" ]; then
+    if [ -x "$JAVA_HOME/jre/sh/java" ]; then
+      # IBM's JDK on AIX uses strange locations for the executables
+      JAVACMD="$JAVA_HOME/jre/sh/java"
+      JAVACCMD="$JAVA_HOME/jre/sh/javac"
+    else
+      JAVACMD="$JAVA_HOME/bin/java"
+      JAVACCMD="$JAVA_HOME/bin/javac"
+
+      if [ ! -x "$JAVACMD" ] || [ ! -x "$JAVACCMD" ]; then
+        echo "The JAVA_HOME environment variable is not defined correctly, so mvnw cannot run." >&2
+        echo "JAVA_HOME is set to \"$JAVA_HOME\", but \"\$JAVA_HOME/bin/java\" or \"\$JAVA_HOME/bin/javac\" does not exist." >&2
+        return 1
+      fi
+    fi
+  else
+    JAVACMD="$(
+      'set' +e
+      'unset' -f command 2>/dev/null
+      'command' -v java
+    )" || :
+    JAVACCMD="$(
+      'set' +e
+      'unset' -f command 2>/dev/null
+      'command' -v javac
+    )" || :
+
+    if [ ! -x "${JAVACMD-}" ] || [ ! -x "${JAVACCMD-}" ]; then
+      echo "The java/javac command does not exist in PATH nor is JAVA_HOME set, so mvnw cannot run." >&2
+      return 1
+    fi
+  fi
+}
+
+# hash string like Java String::hashCode
+hash_string() {
+  str="${1:-}" h=0
+  while [ -n "$str" ]; do
+    char="${str%"${str#?}"}"
+    h=$(((h * 31 + $(LC_CTYPE=C printf %d "'$char")) % 4294967296))
+    str="${str#?}"
+  done
+  printf %x\\n $h
+}
+
+verbose() { :; }
+[ "${MVNW_VERBOSE-}" != true ] || verbose() { printf %s\\n "${1-}"; }
+
+die() {
+  printf %s\\n "$1" >&2
+  exit 1
+}
+
+trim() {
+  # MWRAPPER-139:
+  #   Trims trailing and leading whitespace, carriage returns, tabs, and linefeeds.
+  #   Needed for removing poorly interpreted newline sequences when running in more
+  #   exotic environments such as mingw bash on Windows.
+  printf "%s" "${1}" | tr -d '[:space:]'
+}
+
+scriptDir="$(dirname "$0")"
+scriptName="$(basename "$0")"
+
+# parse distributionUrl and optional distributionSha256Sum, requires .mvn/wrapper/maven-wrapper.properties
+while IFS="=" read -r key value; do
+  case "${key-}" in
+  distributionUrl) distributionUrl=$(trim "${value-}") ;;
+  distributionSha256Sum) distributionSha256Sum=$(trim "${value-}") ;;
+  esac
+done <"$scriptDir/.mvn/wrapper/maven-wrapper.properties"
+[ -n "${distributionUrl-}" ] || die "cannot read distributionUrl property in $scriptDir/.mvn/wrapper/maven-wrapper.properties"
+
+case "${distributionUrl##*/}" in
+maven-mvnd-*bin.*)
+  MVN_CMD=mvnd.sh _MVNW_REPO_PATTERN=/maven/mvnd/
+  case "${PROCESSOR_ARCHITECTURE-}${PROCESSOR_ARCHITEW6432-}:$(uname -a)" in
+  *AMD64:CYGWIN* | *AMD64:MINGW*) distributionPlatform=windows-amd64 ;;
+  :Darwin*x86_64) distributionPlatform=darwin-amd64 ;;
+  :Darwin*arm64) distributionPlatform=darwin-aarch64 ;;
+  :Linux*x86_64*) distributionPlatform=linux-amd64 ;;
+  *)
+    echo "Cannot detect native platform for mvnd on $(uname)-$(uname -m), use pure java version" >&2
+    distributionPlatform=linux-amd64
+    ;;
+  esac
+  distributionUrl="${distributionUrl%-bin.*}-$distributionPlatform.zip"
+  ;;
+maven-mvnd-*) MVN_CMD=mvnd.sh _MVNW_REPO_PATTERN=/maven/mvnd/ ;;
+*) MVN_CMD="mvn${scriptName#mvnw}" _MVNW_REPO_PATTERN=/org/apache/maven/ ;;
+esac
+
+# apply MVNW_REPOURL and calculate MAVEN_HOME
+# maven home pattern: ~/.m2/wrapper/dists/{apache-maven-<version>,maven-mvnd-<version>-<platform>}/<hash>
+[ -z "${MVNW_REPOURL-}" ] || distributionUrl="$MVNW_REPOURL$_MVNW_REPO_PATTERN${distributionUrl#*"$_MVNW_REPO_PATTERN"}"
+distributionUrlName="${distributionUrl##*/}"
+distributionUrlNameMain="${distributionUrlName%.*}"
+distributionUrlNameMain="${distributionUrlNameMain%-bin}"
+MAVEN_USER_HOME="${MAVEN_USER_HOME:-${HOME}/.m2}"
+MAVEN_HOME="${MAVEN_USER_HOME}/wrapper/dists/${distributionUrlNameMain-}/$(hash_string "$distributionUrl")"
+
+exec_maven() {
+  unset MVNW_VERBOSE MVNW_USERNAME MVNW_PASSWORD MVNW_REPOURL || :
+  exec "$MAVEN_HOME/bin/$MVN_CMD" "$@" || die "cannot exec $MAVEN_HOME/bin/$MVN_CMD"
+}
+
+if [ -d "$MAVEN_HOME" ]; then
+  verbose "found existing MAVEN_HOME at $MAVEN_HOME"
+  exec_maven "$@"
+fi
+
+case "${distributionUrl-}" in
+*?-bin.zip | *?maven-mvnd-?*-?*.zip) ;;
+*) die "distributionUrl is not valid, must match *-bin.zip or maven-mvnd-*.zip, but found '${distributionUrl-}'" ;;
+esac
+
+# prepare tmp dir
+if TMP_DOWNLOAD_DIR="$(mktemp -d)" && [ -d "$TMP_DOWNLOAD_DIR" ]; then
+  clean() { rm -rf -- "$TMP_DOWNLOAD_DIR"; }
+  trap clean HUP INT TERM EXIT
+else
+  die "cannot create temp dir"
+fi
+
+mkdir -p -- "${MAVEN_HOME%/*}"
+
+# Download and Install Apache Maven
+verbose "Couldn't find MAVEN_HOME, downloading and installing it ..."
+verbose "Downloading from: $distributionUrl"
+verbose "Downloading to: $TMP_DOWNLOAD_DIR/$distributionUrlName"
+
+# select .zip or .tar.gz
+if ! command -v unzip >/dev/null; then
+  distributionUrl="${distributionUrl%.zip}.tar.gz"
+  distributionUrlName="${distributionUrl##*/}"
+fi
+
+# verbose opt
+__MVNW_QUIET_WGET=--quiet __MVNW_QUIET_CURL=--silent __MVNW_QUIET_UNZIP=-q __MVNW_QUIET_TAR=''
+[ "${MVNW_VERBOSE-}" != true ] || __MVNW_QUIET_WGET='' __MVNW_QUIET_CURL='' __MVNW_QUIET_UNZIP='' __MVNW_QUIET_TAR=v
+
+# normalize http auth
+case "${MVNW_PASSWORD:+has-password}" in
+'') MVNW_USERNAME='' MVNW_PASSWORD='' ;;
+has-password) [ -n "${MVNW_USERNAME-}" ] || MVNW_USERNAME='' MVNW_PASSWORD='' ;;
+esac
+
+if [ -z "${MVNW_USERNAME-}" ] && command -v wget >/dev/null; then
+  verbose "Found wget ... using wget"
+  wget ${__MVNW_QUIET_WGET:+"$__MVNW_QUIET_WGET"} "$distributionUrl" -O "$TMP_DOWNLOAD_DIR/$distributionUrlName" || die "wget: Failed to fetch $distributionUrl"
+elif [ -z "${MVNW_USERNAME-}" ] && command -v curl >/dev/null; then
+  verbose "Found curl ... using curl"
+  curl ${__MVNW_QUIET_CURL:+"$__MVNW_QUIET_CURL"} -f -L -o "$TMP_DOWNLOAD_DIR/$distributionUrlName" "$distributionUrl" || die "curl: Failed to fetch $distributionUrl"
+elif set_java_home; then
+  verbose "Falling back to use Java to download"
+  javaSource="$TMP_DOWNLOAD_DIR/Downloader.java"
+  targetZip="$TMP_DOWNLOAD_DIR/$distributionUrlName"
+  cat >"$javaSource" <<-END
+	public class Downloader extends java.net.Authenticator
+	{
+	  protected java.net.PasswordAuthentication getPasswordAuthentication()
+	  {
+	    return new java.net.PasswordAuthentication( System.getenv( "MVNW_USERNAME" ), System.getenv( "MVNW_PASSWORD" ).toCharArray() );
+	  }
+	  public static void main( String[] args ) throws Exception
+	  {
+	    setDefault( new Downloader() );
+	    java.nio.file.Files.copy( java.net.URI.create( args[0] ).toURL().openStream(), java.nio.file.Paths.get( args[1] ).toAbsolutePath().normalize() );
+	  }
+	}
+	END
+  # For Cygwin/MinGW, switch paths to Windows format before running javac and java
+  verbose " - Compiling Downloader.java ..."
+  "$(native_path "$JAVACCMD")" "$(native_path "$javaSource")" || die "Failed to compile Downloader.java"
+  verbose " - Running Downloader.java ..."
+  "$(native_path "$JAVACMD")" -cp "$(native_path "$TMP_DOWNLOAD_DIR")" Downloader "$distributionUrl" "$(native_path "$targetZip")"
+fi
+
+# If specified, validate the SHA-256 sum of the Maven distribution zip file
+if [ -n "${distributionSha256Sum-}" ]; then
+  distributionSha256Result=false
+  if [ "$MVN_CMD" = mvnd.sh ]; then
+    echo "Checksum validation is not supported for maven-mvnd." >&2
+    echo "Please disable validation by removing 'distributionSha256Sum' from your maven-wrapper.properties." >&2
+    exit 1
+  elif command -v sha256sum >/dev/null; then
+    if echo "$distributionSha256Sum  $TMP_DOWNLOAD_DIR/$distributionUrlName" | sha256sum -c - >/dev/null 2>&1; then
+      distributionSha256Result=true
+    fi
+  elif command -v shasum >/dev/null; then
+    if echo "$distributionSha256Sum  $TMP_DOWNLOAD_DIR/$distributionUrlName" | shasum -a 256 -c >/dev/null 2>&1; then
+      distributionSha256Result=true
+    fi
+  else
+    echo "Checksum validation was requested but neither 'sha256sum' or 'shasum' are available." >&2
+    echo "Please install either command, or disable validation by removing 'distributionSha256Sum' from your maven-wrapper.properties." >&2
+    exit 1
+  fi
+  if [ $distributionSha256Result = false ]; then
+    echo "Error: Failed to validate Maven distribution SHA-256, your Maven distribution might be compromised." >&2
+    echo "If you updated your Maven version, you need to update the specified distributionSha256Sum property." >&2
+    exit 1
+  fi
+fi
+
+# unzip and move
+if command -v unzip >/dev/null; then
+  unzip ${__MVNW_QUIET_UNZIP:+"$__MVNW_QUIET_UNZIP"} "$TMP_DOWNLOAD_DIR/$distributionUrlName" -d "$TMP_DOWNLOAD_DIR" || die "failed to unzip"
+else
+  tar xzf${__MVNW_QUIET_TAR:+"$__MVNW_QUIET_TAR"} "$TMP_DOWNLOAD_DIR/$distributionUrlName" -C "$TMP_DOWNLOAD_DIR" || die "failed to untar"
+fi
+
+# Find the actual extracted directory name (handles snapshots where filename != directory name)
+actualDistributionDir=""
+
+# First try the expected directory name (for regular distributions)
+if [ -d "$TMP_DOWNLOAD_DIR/$distributionUrlNameMain" ]; then
+  if [ -f "$TMP_DOWNLOAD_DIR/$distributionUrlNameMain/bin/$MVN_CMD" ]; then
+    actualDistributionDir="$distributionUrlNameMain"
+  fi
+fi
+
+# If not found, search for any directory with the Maven executable (for snapshots)
+if [ -z "$actualDistributionDir" ]; then
+  # enable globbing to iterate over items
+  set +f
+  for dir in "$TMP_DOWNLOAD_DIR"/*; do
+    if [ -d "$dir" ]; then
+      if [ -f "$dir/bin/$MVN_CMD" ]; then
+        actualDistributionDir="$(basename "$dir")"
+        break
+      fi
+    fi
+  done
+  set -f
+fi
+
+if [ -z "$actualDistributionDir" ]; then
+  verbose "Contents of $TMP_DOWNLOAD_DIR:"
+  verbose "$(ls -la "$TMP_DOWNLOAD_DIR")"
+  die "Could not find Maven distribution directory in extracted archive"
+fi
+
+verbose "Found extracted Maven distribution directory: $actualDistributionDir"
+printf %s\\n "$distributionUrl" >"$TMP_DOWNLOAD_DIR/$actualDistributionDir/mvnw.url"
+mv -- "$TMP_DOWNLOAD_DIR/$actualDistributionDir" "$MAVEN_HOME" || [ -d "$MAVEN_HOME" ] || die "fail to move MAVEN_HOME"
+
+clean || :
+exec_maven "$@"

--- a/circular-reference-demo/mvnw.cmd
+++ b/circular-reference-demo/mvnw.cmd
@@ -1,0 +1,189 @@
+<# : batch portion
+@REM ----------------------------------------------------------------------------
+@REM Licensed to the Apache Software Foundation (ASF) under one
+@REM or more contributor license agreements.  See the NOTICE file
+@REM distributed with this work for additional information
+@REM regarding copyright ownership.  The ASF licenses this file
+@REM to you under the Apache License, Version 2.0 (the
+@REM "License"); you may not use this file except in compliance
+@REM with the License.  You may obtain a copy of the License at
+@REM
+@REM    http://www.apache.org/licenses/LICENSE-2.0
+@REM
+@REM Unless required by applicable law or agreed to in writing,
+@REM software distributed under the License is distributed on an
+@REM "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+@REM KIND, either express or implied.  See the License for the
+@REM specific language governing permissions and limitations
+@REM under the License.
+@REM ----------------------------------------------------------------------------
+
+@REM ----------------------------------------------------------------------------
+@REM Apache Maven Wrapper startup batch script, version 3.3.4
+@REM
+@REM Optional ENV vars
+@REM   MVNW_REPOURL - repo url base for downloading maven distribution
+@REM   MVNW_USERNAME/MVNW_PASSWORD - user and password for downloading maven
+@REM   MVNW_VERBOSE - true: enable verbose log; others: silence the output
+@REM ----------------------------------------------------------------------------
+
+@IF "%__MVNW_ARG0_NAME__%"=="" (SET __MVNW_ARG0_NAME__=%~nx0)
+@SET __MVNW_CMD__=
+@SET __MVNW_ERROR__=
+@SET __MVNW_PSMODULEP_SAVE=%PSModulePath%
+@SET PSModulePath=
+@FOR /F "usebackq tokens=1* delims==" %%A IN (`powershell -noprofile "& {$scriptDir='%~dp0'; $script='%__MVNW_ARG0_NAME__%'; icm -ScriptBlock ([Scriptblock]::Create((Get-Content -Raw '%~f0'))) -NoNewScope}"`) DO @(
+  IF "%%A"=="MVN_CMD" (set __MVNW_CMD__=%%B) ELSE IF "%%B"=="" (echo %%A) ELSE (echo %%A=%%B)
+)
+@SET PSModulePath=%__MVNW_PSMODULEP_SAVE%
+@SET __MVNW_PSMODULEP_SAVE=
+@SET __MVNW_ARG0_NAME__=
+@SET MVNW_USERNAME=
+@SET MVNW_PASSWORD=
+@IF NOT "%__MVNW_CMD__%"=="" ("%__MVNW_CMD__%" %*)
+@echo Cannot start maven from wrapper >&2 && exit /b 1
+@GOTO :EOF
+: end batch / begin powershell #>
+
+$ErrorActionPreference = "Stop"
+if ($env:MVNW_VERBOSE -eq "true") {
+  $VerbosePreference = "Continue"
+}
+
+# calculate distributionUrl, requires .mvn/wrapper/maven-wrapper.properties
+$distributionUrl = (Get-Content -Raw "$scriptDir/.mvn/wrapper/maven-wrapper.properties" | ConvertFrom-StringData).distributionUrl
+if (!$distributionUrl) {
+  Write-Error "cannot read distributionUrl property in $scriptDir/.mvn/wrapper/maven-wrapper.properties"
+}
+
+switch -wildcard -casesensitive ( $($distributionUrl -replace '^.*/','') ) {
+  "maven-mvnd-*" {
+    $USE_MVND = $true
+    $distributionUrl = $distributionUrl -replace '-bin\.[^.]*$',"-windows-amd64.zip"
+    $MVN_CMD = "mvnd.cmd"
+    break
+  }
+  default {
+    $USE_MVND = $false
+    $MVN_CMD = $script -replace '^mvnw','mvn'
+    break
+  }
+}
+
+# apply MVNW_REPOURL and calculate MAVEN_HOME
+# maven home pattern: ~/.m2/wrapper/dists/{apache-maven-<version>,maven-mvnd-<version>-<platform>}/<hash>
+if ($env:MVNW_REPOURL) {
+  $MVNW_REPO_PATTERN = if ($USE_MVND -eq $False) { "/org/apache/maven/" } else { "/maven/mvnd/" }
+  $distributionUrl = "$env:MVNW_REPOURL$MVNW_REPO_PATTERN$($distributionUrl -replace "^.*$MVNW_REPO_PATTERN",'')"
+}
+$distributionUrlName = $distributionUrl -replace '^.*/',''
+$distributionUrlNameMain = $distributionUrlName -replace '\.[^.]*$','' -replace '-bin$',''
+
+$MAVEN_M2_PATH = "$HOME/.m2"
+if ($env:MAVEN_USER_HOME) {
+  $MAVEN_M2_PATH = "$env:MAVEN_USER_HOME"
+}
+
+if (-not (Test-Path -Path $MAVEN_M2_PATH)) {
+    New-Item -Path $MAVEN_M2_PATH -ItemType Directory | Out-Null
+}
+
+$MAVEN_WRAPPER_DISTS = $null
+if ((Get-Item $MAVEN_M2_PATH).Target[0] -eq $null) {
+  $MAVEN_WRAPPER_DISTS = "$MAVEN_M2_PATH/wrapper/dists"
+} else {
+  $MAVEN_WRAPPER_DISTS = (Get-Item $MAVEN_M2_PATH).Target[0] + "/wrapper/dists"
+}
+
+$MAVEN_HOME_PARENT = "$MAVEN_WRAPPER_DISTS/$distributionUrlNameMain"
+$MAVEN_HOME_NAME = ([System.Security.Cryptography.SHA256]::Create().ComputeHash([byte[]][char[]]$distributionUrl) | ForEach-Object {$_.ToString("x2")}) -join ''
+$MAVEN_HOME = "$MAVEN_HOME_PARENT/$MAVEN_HOME_NAME"
+
+if (Test-Path -Path "$MAVEN_HOME" -PathType Container) {
+  Write-Verbose "found existing MAVEN_HOME at $MAVEN_HOME"
+  Write-Output "MVN_CMD=$MAVEN_HOME/bin/$MVN_CMD"
+  exit $?
+}
+
+if (! $distributionUrlNameMain -or ($distributionUrlName -eq $distributionUrlNameMain)) {
+  Write-Error "distributionUrl is not valid, must end with *-bin.zip, but found $distributionUrl"
+}
+
+# prepare tmp dir
+$TMP_DOWNLOAD_DIR_HOLDER = New-TemporaryFile
+$TMP_DOWNLOAD_DIR = New-Item -Itemtype Directory -Path "$TMP_DOWNLOAD_DIR_HOLDER.dir"
+$TMP_DOWNLOAD_DIR_HOLDER.Delete() | Out-Null
+trap {
+  if ($TMP_DOWNLOAD_DIR.Exists) {
+    try { Remove-Item $TMP_DOWNLOAD_DIR -Recurse -Force | Out-Null }
+    catch { Write-Warning "Cannot remove $TMP_DOWNLOAD_DIR" }
+  }
+}
+
+New-Item -Itemtype Directory -Path "$MAVEN_HOME_PARENT" -Force | Out-Null
+
+# Download and Install Apache Maven
+Write-Verbose "Couldn't find MAVEN_HOME, downloading and installing it ..."
+Write-Verbose "Downloading from: $distributionUrl"
+Write-Verbose "Downloading to: $TMP_DOWNLOAD_DIR/$distributionUrlName"
+
+$webclient = New-Object System.Net.WebClient
+if ($env:MVNW_USERNAME -and $env:MVNW_PASSWORD) {
+  $webclient.Credentials = New-Object System.Net.NetworkCredential($env:MVNW_USERNAME, $env:MVNW_PASSWORD)
+}
+[Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
+$webclient.DownloadFile($distributionUrl, "$TMP_DOWNLOAD_DIR/$distributionUrlName") | Out-Null
+
+# If specified, validate the SHA-256 sum of the Maven distribution zip file
+$distributionSha256Sum = (Get-Content -Raw "$scriptDir/.mvn/wrapper/maven-wrapper.properties" | ConvertFrom-StringData).distributionSha256Sum
+if ($distributionSha256Sum) {
+  if ($USE_MVND) {
+    Write-Error "Checksum validation is not supported for maven-mvnd. `nPlease disable validation by removing 'distributionSha256Sum' from your maven-wrapper.properties."
+  }
+  Import-Module $PSHOME\Modules\Microsoft.PowerShell.Utility -Function Get-FileHash
+  if ((Get-FileHash "$TMP_DOWNLOAD_DIR/$distributionUrlName" -Algorithm SHA256).Hash.ToLower() -ne $distributionSha256Sum) {
+    Write-Error "Error: Failed to validate Maven distribution SHA-256, your Maven distribution might be compromised. If you updated your Maven version, you need to update the specified distributionSha256Sum property."
+  }
+}
+
+# unzip and move
+Expand-Archive "$TMP_DOWNLOAD_DIR/$distributionUrlName" -DestinationPath "$TMP_DOWNLOAD_DIR" | Out-Null
+
+# Find the actual extracted directory name (handles snapshots where filename != directory name)
+$actualDistributionDir = ""
+
+# First try the expected directory name (for regular distributions)
+$expectedPath = Join-Path "$TMP_DOWNLOAD_DIR" "$distributionUrlNameMain"
+$expectedMvnPath = Join-Path "$expectedPath" "bin/$MVN_CMD"
+if ((Test-Path -Path $expectedPath -PathType Container) -and (Test-Path -Path $expectedMvnPath -PathType Leaf)) {
+  $actualDistributionDir = $distributionUrlNameMain
+}
+
+# If not found, search for any directory with the Maven executable (for snapshots)
+if (!$actualDistributionDir) {
+  Get-ChildItem -Path "$TMP_DOWNLOAD_DIR" -Directory | ForEach-Object {
+    $testPath = Join-Path $_.FullName "bin/$MVN_CMD"
+    if (Test-Path -Path $testPath -PathType Leaf) {
+      $actualDistributionDir = $_.Name
+    }
+  }
+}
+
+if (!$actualDistributionDir) {
+  Write-Error "Could not find Maven distribution directory in extracted archive"
+}
+
+Write-Verbose "Found extracted Maven distribution directory: $actualDistributionDir"
+Rename-Item -Path "$TMP_DOWNLOAD_DIR/$actualDistributionDir" -NewName $MAVEN_HOME_NAME | Out-Null
+try {
+  Move-Item -Path "$TMP_DOWNLOAD_DIR/$MAVEN_HOME_NAME" -Destination $MAVEN_HOME_PARENT | Out-Null
+} catch {
+  if (! (Test-Path -Path "$MAVEN_HOME" -PathType Container)) {
+    Write-Error "fail to move MAVEN_HOME"
+  }
+} finally {
+  try { Remove-Item $TMP_DOWNLOAD_DIR -Recurse -Force | Out-Null }
+  catch { Write-Warning "Cannot remove $TMP_DOWNLOAD_DIR" }
+}
+
+Write-Output "MVN_CMD=$MAVEN_HOME/bin/$MVN_CMD"

--- a/circular-reference-demo/pom.xml
+++ b/circular-reference-demo/pom.xml
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>org.springframework.boot</groupId>
+        <artifactId>spring-boot-starter-parent</artifactId>
+        <version>3.3.0</version>
+        <relativePath/>
+    </parent>
+
+    <groupId>com.example</groupId>
+    <artifactId>circular-reference-demo</artifactId>
+    <version>0.0.1-SNAPSHOT</version>
+
+    <properties>
+        <java.version>17</java.version>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-test</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.springframework.boot</groupId>
+                <artifactId>spring-boot-maven-plugin</artifactId>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/circular-reference-demo/src/main/java/com/example/circular/CircularReferenceApplication.java
+++ b/circular-reference-demo/src/main/java/com/example/circular/CircularReferenceApplication.java
@@ -1,0 +1,24 @@
+package com.example.circular;
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+
+/**
+ * 시나리오별 실행 방법:
+ *
+ * 1. [bad]  생성자 순환 참조 → 앱 시작 실패
+ *    ./mvnw exec:java -Dexec.mainClass=com.example.circular.bad.BadApp
+ *
+ * 2. [lazy] @Lazy로 우회 → 시작은 되지만 설계 문제 잔존
+ *    ./mvnw exec:java -Dexec.mainClass=com.example.circular.lazy.LazyApp
+ *
+ * 3. [good] CommonPolicy 분리 → 순환 참조 자체가 없음
+ *    ./mvnw exec:java -Dexec.mainClass=com.example.circular.good.GoodApp
+ */
+@SpringBootApplication(scanBasePackages = "com.example.circular.good")
+public class CircularReferenceApplication {
+
+    public static void main(String[] args) {
+        SpringApplication.run(CircularReferenceApplication.class, args);
+    }
+}

--- a/circular-reference-demo/src/main/java/com/example/circular/bad/AService.java
+++ b/circular-reference-demo/src/main/java/com/example/circular/bad/AService.java
@@ -1,0 +1,18 @@
+package com.example.circular.bad;
+
+import org.springframework.stereotype.Service;
+
+// [bad] AService ↔ BService 생성자 순환 참조 - 앱 시작 시 BeanCurrentlyInCreationException 발생
+@Service
+public class AService {
+
+    private final BService bService;
+
+    public AService(BService bService) {
+        this.bService = bService;
+    }
+
+    public String hello() {
+        return "AService -> " + bService.greet();
+    }
+}

--- a/circular-reference-demo/src/main/java/com/example/circular/bad/BService.java
+++ b/circular-reference-demo/src/main/java/com/example/circular/bad/BService.java
@@ -1,0 +1,21 @@
+package com.example.circular.bad;
+
+import org.springframework.stereotype.Service;
+
+@Service
+public class BService {
+
+    private final AService aService;
+
+    public BService(AService aService) {
+        this.aService = aService;
+    }
+
+    public String greet() {
+        return "BService";
+    }
+
+    public String hello() {
+        return "BService -> " + aService.hello();
+    }
+}

--- a/circular-reference-demo/src/main/java/com/example/circular/bad/BadApp.java
+++ b/circular-reference-demo/src/main/java/com/example/circular/bad/BadApp.java
@@ -1,0 +1,13 @@
+package com.example.circular.bad;
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+
+// [bad] AService ↔ BService 생성자 순환 참조 → 앱 시작 시 BeanCurrentlyInCreationException 발생
+@SpringBootApplication
+public class BadApp {
+
+    public static void main(String[] args) {
+        SpringApplication.run(BadApp.class, args);
+    }
+}

--- a/circular-reference-demo/src/main/java/com/example/circular/good/AService.java
+++ b/circular-reference-demo/src/main/java/com/example/circular/good/AService.java
@@ -1,0 +1,18 @@
+package com.example.circular.good;
+
+import org.springframework.stereotype.Service;
+
+// [good] AService는 BService를 모름 - CommonPolicy만 의존
+@Service
+public class AService {
+
+    private final CommonPolicy commonPolicy;
+
+    public AService(CommonPolicy commonPolicy) {
+        this.commonPolicy = commonPolicy;
+    }
+
+    public String hello() {
+        return "AService -> " + commonPolicy.greet();
+    }
+}

--- a/circular-reference-demo/src/main/java/com/example/circular/good/BService.java
+++ b/circular-reference-demo/src/main/java/com/example/circular/good/BService.java
@@ -1,0 +1,18 @@
+package com.example.circular.good;
+
+import org.springframework.stereotype.Service;
+
+// [good] BService도 AService를 모름 - CommonPolicy만 의존
+@Service
+public class BService {
+
+    private final CommonPolicy commonPolicy;
+
+    public BService(CommonPolicy commonPolicy) {
+        this.commonPolicy = commonPolicy;
+    }
+
+    public String hello() {
+        return "BService -> " + commonPolicy.greet();
+    }
+}

--- a/circular-reference-demo/src/main/java/com/example/circular/good/CommonPolicy.java
+++ b/circular-reference-demo/src/main/java/com/example/circular/good/CommonPolicy.java
@@ -1,0 +1,12 @@
+package com.example.circular.good;
+
+import org.springframework.stereotype.Component;
+
+// [good] 두 서비스가 공통으로 필요한 로직을 별도 컴포넌트로 분리
+@Component
+public class CommonPolicy {
+
+    public String greet() {
+        return "CommonPolicy";
+    }
+}

--- a/circular-reference-demo/src/main/java/com/example/circular/good/GoodApp.java
+++ b/circular-reference-demo/src/main/java/com/example/circular/good/GoodApp.java
@@ -1,0 +1,23 @@
+package com.example.circular.good;
+
+import org.springframework.boot.CommandLineRunner;
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.context.annotation.Bean;
+
+// [good] CommonPolicy 분리로 순환 참조 자체를 제거
+@SpringBootApplication
+public class GoodApp {
+
+    public static void main(String[] args) {
+        SpringApplication.run(GoodApp.class, args);
+    }
+
+    @Bean
+    CommandLineRunner run(AService aService, BService bService) {
+        return args -> {
+            System.out.println("[good] " + aService.hello());
+            System.out.println("[good] " + bService.hello());
+        };
+    }
+}

--- a/circular-reference-demo/src/main/java/com/example/circular/lazy/AService.java
+++ b/circular-reference-demo/src/main/java/com/example/circular/lazy/AService.java
@@ -1,0 +1,19 @@
+package com.example.circular.lazy;
+
+import org.springframework.context.annotation.Lazy;
+import org.springframework.stereotype.Service;
+
+// [lazy] @Lazy로 순환 참조 우회 - 시작 오류는 피하지만 설계 문제는 그대로 남음
+@Service
+public class AService {
+
+    private final BService bService;
+
+    public AService(@Lazy BService bService) {
+        this.bService = bService;
+    }
+
+    public String hello() {
+        return "AService -> " + bService.greet();
+    }
+}

--- a/circular-reference-demo/src/main/java/com/example/circular/lazy/BService.java
+++ b/circular-reference-demo/src/main/java/com/example/circular/lazy/BService.java
@@ -1,0 +1,21 @@
+package com.example.circular.lazy;
+
+import org.springframework.stereotype.Service;
+
+@Service
+public class BService {
+
+    private final AService aService;
+
+    public BService(AService aService) {
+        this.aService = aService;
+    }
+
+    public String greet() {
+        return "BService";
+    }
+
+    public String hello() {
+        return "BService -> " + aService.hello();
+    }
+}

--- a/circular-reference-demo/src/main/java/com/example/circular/lazy/LazyApp.java
+++ b/circular-reference-demo/src/main/java/com/example/circular/lazy/LazyApp.java
@@ -1,0 +1,20 @@
+package com.example.circular.lazy;
+
+import org.springframework.boot.CommandLineRunner;
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.context.annotation.Bean;
+
+// [lazy] @Lazy로 순환 참조 우회 → 시작은 성공하지만 서비스 간 의존 구조는 그대로 남음
+@SpringBootApplication
+public class LazyApp {
+
+    public static void main(String[] args) {
+        SpringApplication.run(LazyApp.class, args);
+    }
+
+    @Bean
+    CommandLineRunner run(AService aService) {
+        return args -> System.out.println("[lazy] " + aService.hello());
+    }
+}

--- a/circular-reference-demo/src/main/resources/application.properties
+++ b/circular-reference-demo/src/main/resources/application.properties
@@ -1,0 +1,1 @@
+spring.main.web-application-type=none

--- a/spring-bean-circular-reference.md
+++ b/spring-bean-circular-reference.md
@@ -1,0 +1,713 @@
+# Spring Bean 순환 참조 해결 사례
+
+## 1. 발표 주제
+
+이번 발표에서는 **Spring Bean 순환 참조**가 무엇인지, 왜 문제가 되는지, 그리고 어떻게 해결하는 것이 좋은지 설명합니다.
+
+특히 eGovFrame VSCode Initializr처럼 Spring 기반 코드를 생성하는 프로젝트에서는 사용자가 생성된 코드를 확장하다가 의존 관계를 잘못 설계하면 순환 참조가 발생할 수 있습니다.
+
+그래서 이번 발표의 핵심은 다음과 같습니다.
+
+```text
+Spring Bean 순환 참조는 단순한 오류가 아니라
+객체 사이의 책임과 의존 방향이 잘못 설계되었다는 신호일 수 있다.
+```
+
+---
+
+## 2. 먼저 Bean이 무엇인지부터 이해하기
+
+Spring에서 **Bean**은 Spring 컨테이너가 직접 생성하고 관리하는 객체입니다.
+
+예를 들어 다음과 같은 클래스가 있다고 해보겠습니다.
+
+```java
+@Service
+public class MemberService {
+}
+```
+
+여기서 `@Service`가 붙어 있으면 Spring은 이 클래스를 보고 “이 객체는 내가 대신 만들어서 관리해야겠다”라고 판단합니다.
+
+이렇게 Spring이 관리하는 객체를 **Bean**이라고 부릅니다.
+
+쉽게 말하면 다음과 같습니다.
+
+```text
+일반 객체:
+개발자가 직접 new로 생성하는 객체
+
+Spring Bean:
+Spring이 대신 생성하고 관리해주는 객체(제어의 역전)
+```
+
+예를 들어 직접 객체를 만들면 다음과 같습니다.
+
+```java
+MemberService memberService = new MemberService();
+```
+
+하지만 Spring에서는 보통 이렇게 직접 만들지 않습니다.
+
+대신 Spring이 애플리케이션 실행 시점에 객체를 만들고, 필요한 곳에 자동으로 넣어줍니다.
+
+이 과정을 **의존성 주입(Dependency Injection)** 이라고 합니다.
+
+---
+
+## 3. 의존성 주입이란?
+
+의존성 주입은 어떤 객체가 필요한 다른 객체를 직접 만들지 않고, 외부에서 전달받는 방식입니다.
+
+예를 들어 `MemberController`가 `MemberService`를 사용해야 한다고 해보겠습니다.
+
+```java
+@RestController
+public class MemberController {
+
+    private final MemberService memberService;
+
+    public MemberController(MemberService memberService) {
+        this.memberService = memberService;
+    }
+}
+```
+
+여기서 `MemberController`는 `MemberService`를 직접 `new`로 만들지 않습니다.
+
+대신 생성자를 통해 `MemberService`를 전달받습니다.
+
+```text
+MemberController는 MemberService가 필요하다.
+그런데 직접 만들지 않고 Spring에게 받아서 사용한다.
+```
+
+Spring은 애플리케이션을 실행할 때 다음과 같이 생각합니다.
+
+```text
+1. MemberService Bean을 만든다.
+2. MemberController Bean을 만든다.
+3. MemberController를 만들 때 MemberService를 넣어준다.
+```
+
+이처럼 객체 생성과 연결을 Spring이 대신 처리해주기 때문에 개발자는 비즈니스 로직에 더 집중할 수 있습니다.
+
+---
+
+## 4. 순환 참조란?
+
+순환 참조는 두 개 이상의 객체가 서로를 필요로 하는 구조입니다.
+
+가장 단순한 예시는 다음과 같습니다.
+
+```text
+AService → BService
+BService → AService
+```
+
+즉, AService는 BService가 필요하고, BService도 다시 AService가 필요한 상황입니다.
+
+코드로 보면 다음과 같습니다.
+
+```java
+@Service
+public class AService {
+
+    private final BService bService;
+
+    public AService(BService bService) {
+        this.bService = bService;
+    }
+}
+```
+
+```java
+@Service
+public class BService {
+
+    private final AService aService;
+
+    public BService(AService aService) {
+        this.aService = aService;
+    }
+}
+```
+
+이 구조에서는 Spring이 객체를 만들 때 곤란해집니다.
+
+Spring 입장에서 생각해보면 다음과 같습니다.
+
+```text
+AService를 만들려면 BService가 필요하다.
+그런데 BService를 만들려면 AService가 필요하다.
+그런데 AService를 만들려면 다시 BService가 필요하다.
+...
+```
+
+결국 끝나지 않는 의존 관계가 만들어집니다.
+
+그래서 이런 구조를 **Spring Bean 순환 참조(Spring Bean Circular Reference)** 라고 합니다.
+
+---
+
+## 5. 순환 참조를 일상적인 비유로 이해하기
+
+순환 참조는 일상생활로 비유하면 더 쉽게 이해할 수 있습니다.
+
+두 사람이 서로에게 이렇게 말하는 상황을 생각해보겠습니다.
+
+```text
+A: 나는 B가 와야 출발할 수 있어.
+B: 나는 A가 와야 출발할 수 있어.
+```
+
+그러면 둘 다 출발하지 못합니다.
+
+A가 먼저 움직이려면 B가 필요하고, B가 먼저 움직이려면 A가 필요하기 때문입니다.
+
+Spring Bean 순환 참조도 비슷합니다.
+
+```text
+AService가 생성되려면 BService가 필요하다.
+BService가 생성되려면 AService가 필요하다.
+```
+
+결과적으로 Spring은 어떤 Bean을 먼저 완성해야 하는지 결정하기 어려워집니다.
+
+---
+
+## 6. 왜 순환 참조가 문제가 될까?
+
+순환 참조가 문제가 되는 이유는 단순히 애플리케이션 실행이 실패할 수 있기 때문만은 아닙니다.
+
+더 중요한 이유는 **설계가 복잡해지고 책임이 섞였다는 신호**일 수 있기 때문입니다.
+
+예를 들어 다음 구조를 보겠습니다.
+
+```text
+OrderService → StockService
+StockService → OrderService
+```
+
+주문 서비스가 재고 서비스를 호출하는 것은 자연스러울 수 있습니다.
+
+```text
+주문을 생성하려면 재고를 확인해야 한다.
+```
+
+하지만 재고 서비스가 다시 주문 서비스를 호출한다면 구조가 복잡해집니다.
+
+```text
+재고를 처리하려면 주문 정보를 다시 확인해야 한다.
+```
+
+이런 구조가 반복되면 다음 문제가 생깁니다.
+
+```text
+1. 어떤 서비스가 어떤 책임을 가지는지 불분명해진다.
+2. 서비스끼리 너무 강하게 묶인다.
+3. 테스트하기 어려워진다.
+4. 하나를 수정하면 다른 곳까지 영향을 받는다.
+5. 애플리케이션 시작 시점에 Bean 생성 오류가 발생할 수 있다.
+```
+
+따라서 순환 참조는 단순한 문법 문제가 아니라 **객체 설계와 계층 구조의 문제**로 바라보는 것이 좋습니다.
+
+---
+
+## 7. eGovFrame VSCode Initializr에서의 맥락
+
+eGovFrame VSCode Initializr는 eGovFrame 기반 프로젝트와 CRUD 코드를 생성하는 VS Code 확장입니다.
+
+CRUD 코드 생성에서는 보통 다음과 같은 계층 구조가 만들어집니다.
+
+```text
+Controller
+    ↓
+Service
+    ↓
+ServiceImpl
+    ↓
+Mapper
+```
+
+각 계층의 역할은 다음과 같습니다.
+
+```text
+Controller:
+사용자의 요청을 받는 계층
+
+Service:
+비즈니스 흐름을 처리하는 계층
+
+ServiceImpl:
+Service 인터페이스의 실제 구현체
+
+Mapper:
+데이터베이스 접근을 담당하는 계층
+```
+
+이 구조에서 중요한 점은 **의존 방향이 한쪽으로 흐른다**는 것입니다.
+
+```text
+Controller → Service → Mapper
+```
+
+Controller는 Service를 알아도 됩니다. Service는 Mapper를 알아도 됩니다.
+
+하지만 Mapper가 Service를 알거나, Service가 Controller를 알면 구조가 이상해집니다.
+
+---
+
+## 8. 정상적인 계층 구조 예시
+
+정상적인 구조는 다음과 같습니다.
+
+```java
+@Controller
+public class SampleController {
+
+    private final SampleService sampleService;
+
+    public SampleController(SampleService sampleService) {
+        this.sampleService = sampleService;
+    }
+}
+```
+
+```java
+public interface SampleService {
+    void createSample();
+}
+```
+
+```java
+@Service
+public class SampleServiceImpl implements SampleService {
+
+    private final SampleMapper sampleMapper;
+
+    public SampleServiceImpl(SampleMapper sampleMapper) {
+        this.sampleMapper = sampleMapper;
+    }
+
+    @Override
+    public void createSample() {
+        sampleMapper.insertSample();
+    }
+}
+```
+
+```java
+@Mapper
+public interface SampleMapper {
+    void insertSample();
+}
+```
+
+이 구조의 흐름은 다음과 같습니다.
+
+```text
+SampleController
+    ↓
+SampleService
+    ↓
+SampleServiceImpl
+    ↓
+SampleMapper
+```
+
+요청을 받는 쪽에서 비즈니스 계층으로, 비즈니스 계층에서 데이터 접근 계층으로 흐릅니다.
+
+이런 구조는 이해하기 쉽고 테스트하기도 좋습니다.
+
+---
+
+## 9. 순환 참조가 생기는 잘못된 예시
+
+문제는 서비스를 확장하다가 다음과 같은 구조가 생길 때입니다.
+
+```text
+SampleServiceImpl → AnotherService
+AnotherServiceImpl → SampleService
+```
+
+코드로 보면 다음과 같습니다.
+
+```java
+@Service
+public class SampleServiceImpl implements SampleService {
+
+    private final AnotherService anotherService;
+
+    public SampleServiceImpl(AnotherService anotherService) {
+        this.anotherService = anotherService;
+    }
+}
+```
+
+```java
+@Service
+public class AnotherServiceImpl implements AnotherService {
+
+    private final SampleService sampleService;
+
+    public AnotherServiceImpl(SampleService sampleService) {
+        this.sampleService = sampleService;
+    }
+}
+```
+
+이 경우 Spring은 다음과 같은 상황에 빠집니다.
+
+```text
+SampleServiceImpl을 만들려면 AnotherService가 필요하다.
+AnotherServiceImpl을 만들려면 SampleService가 필요하다.
+SampleService는 다시 SampleServiceImpl을 의미한다.
+결국 다시 처음으로 돌아간다.
+```
+
+그 결과 애플리케이션 시작 단계에서 오류가 발생할 수 있습니다.
+
+---
+
+## 10. 임시 해결 방법: @Lazy
+
+순환 참조가 발생했을 때 `@Lazy`를 사용하면 당장 오류를 피할 수 있는 경우가 있습니다.
+
+```java
+@Service
+public class SampleServiceImpl implements SampleService {
+
+    private final AnotherService anotherService;
+
+    public SampleServiceImpl(@Lazy AnotherService anotherService) {
+        this.anotherService = anotherService;
+    }
+}
+```
+
+`@Lazy`는 Bean을 즉시 생성하지 않고, 실제로 필요할 때 늦게 생성하도록 합니다.
+
+그래서 순환 참조 문제를 우회할 수 있습니다.
+
+하지만 이 방식은 근본적인 해결이 아닙니다.
+
+```text
+문제의 원인:
+서비스끼리 서로 의존하는 구조
+
+@Lazy의 효과:
+Bean 생성을 늦춰서 당장 실행되게 함
+
+남아 있는 문제:
+서비스 간 책임이 섞인 구조는 그대로 남아 있음
+```
+
+즉, `@Lazy`는 임시 처방일 수는 있지만 좋은 설계 개선이라고 보기는 어렵습니다.
+
+---
+
+## 11. 임시 해결 방법: allow-circular-references
+
+또 다른 방법은 설정으로 순환 참조를 허용하는 것입니다.
+
+```properties
+spring.main.allow-circular-references=true
+```
+
+이 설정을 사용하면 Spring Boot에서 순환 참조를 허용할 수 있습니다.
+
+하지만 이것도 근본적인 해결 방법은 아닙니다.
+
+왜냐하면 잘못된 의존 구조를 그대로 둔 채, Spring에게 “이 구조를 그냥 허용해줘”라고 말하는 것이기 때문입니다.
+
+오픈소스 프로젝트나 코드 생성 도구에서는 이런 방식보다 사용자에게 더 좋은 구조를 안내하는 것이 중요합니다.
+
+따라서 권장 방향은 다음과 같습니다.
+
+```text
+설정으로 숨기기보다
+의존 구조를 개선한다.
+```
+
+---
+
+## 12. 좋은 해결 방법 1: 공통 책임 분리하기
+
+가장 대표적인 해결 방법은 **두 서비스가 함께 필요로 하는 로직을 별도 객체로 분리하는 것**입니다.
+
+문제가 되는 구조는 다음과 같습니다.
+
+```text
+AService ↔ BService
+```
+
+이 구조를 다음과 같이 바꿀 수 있습니다.
+
+```text
+AService → CommonPolicy
+BService → CommonPolicy
+```
+
+예를 들어 두 서비스가 모두 같은 검증 로직을 필요로 한다고 해보겠습니다.
+
+처음에는 다음처럼 서로를 호출할 수 있습니다.
+
+```text
+SampleService는 AnotherService의 검증 기능이 필요하다.
+AnotherService는 SampleService의 상태 확인 기능이 필요하다.
+```
+
+이 경우 검증과 상태 확인 로직을 별도 컴포넌트로 분리할 수 있습니다.
+
+```java
+@Component
+public class SamplePolicy {
+
+    public boolean canUpdate(SampleVO sample) {
+        // 수정 가능한 상태인지 판단하는 공통 로직
+        return true;
+    }
+}
+```
+
+그리고 두 서비스는 서로를 직접 참조하지 않고 `SamplePolicy`를 사용합니다.
+
+```java
+@Service
+public class SampleServiceImpl implements SampleService {
+
+    private final SamplePolicy samplePolicy;
+
+    public SampleServiceImpl(SamplePolicy samplePolicy) {
+        this.samplePolicy = samplePolicy;
+    }
+}
+```
+
+```java
+@Service
+public class AnotherServiceImpl implements AnotherService {
+
+    private final SamplePolicy samplePolicy;
+
+    public AnotherServiceImpl(SamplePolicy samplePolicy) {
+        this.samplePolicy = samplePolicy;
+    }
+}
+```
+
+이제 구조는 다음과 같이 바뀝니다.
+
+```text
+SampleServiceImpl
+    ↓
+SamplePolicy
+
+AnotherServiceImpl
+    ↓
+SamplePolicy
+```
+
+두 서비스가 서로를 직접 알 필요가 없어졌습니다.
+
+이렇게 하면 순환 참조도 사라지고, 공통 로직도 한 곳에서 관리할 수 있습니다.
+
+---
+
+## 13. 좋은 해결 방법 2: Facade로 흐름 조정하기
+
+두 서비스가 서로를 호출하는 이유가 하나의 큰 업무 흐름을 처리하기 위해서라면 **Facade**를 사용할 수 있습니다.
+
+예를 들어 주문 생성 과정을 생각해보겠습니다.
+
+```text
+1. 재고를 확인한다.
+2. 재고를 차감한다.
+3. 주문을 생성한다.
+```
+
+이때 OrderService와 StockService가 서로를 호출하면 순환 참조가 생길 수 있습니다.
+
+잘못된 구조:
+
+```text
+OrderService → StockService
+StockService → OrderService
+```
+
+개선된 구조:
+
+```text
+OrderFacade
+    ↓
+OrderService
+    ↓
+StockService
+```
+
+예시 코드는 다음과 같습니다.
+
+```java
+@Service
+public class OrderFacade {
+
+    private final OrderService orderService;
+    private final StockService stockService;
+
+    public OrderFacade(OrderService orderService, StockService stockService) {
+        this.orderService = orderService;
+        this.stockService = stockService;
+    }
+
+    public void createOrder(OrderRequest request) {
+        stockService.decreaseStock(request);
+        orderService.createOrder(request);
+    }
+}
+```
+
+여기서 중요한 점은 `OrderService`와 `StockService`가 서로를 직접 호출하지 않는다는 것입니다.
+
+업무 흐름은 `OrderFacade`가 조정합니다.
+
+각 서비스는 자신의 책임에 집중합니다.
+
+```text
+OrderService:
+주문 생성 책임
+
+StockService:
+재고 처리 책임
+
+OrderFacade:
+주문 생성이라는 전체 흐름 조정
+```
+
+이렇게 하면 서비스 간 결합도가 낮아집니다.
+
+---
+
+## 14. 좋은 해결 방법 3: 계층 방향 지키기
+
+Spring 기반 애플리케이션에서는 계층 방향을 지키는 것이 중요합니다.
+
+권장 방향은 다음과 같습니다.
+
+```text
+Controller → Service → Mapper
+```
+
+피해야 하는 방향은 다음과 같습니다.
+
+```text
+Service → Controller
+Mapper → Service
+ServiceA ↔ ServiceB
+```
+
+예를 들어 다음 코드는 좋지 않습니다.
+
+```java
+@Service
+public class SampleServiceImpl {
+
+    private final SampleController sampleController;
+
+    public SampleServiceImpl(SampleController sampleController) {
+        this.sampleController = sampleController;
+    }
+}
+```
+
+왜 좋지 않을까요?
+
+Controller는 사용자의 요청을 받는 계층입니다. Service는 비즈니스 로직을 처리하는 계층입니다.
+
+Service가 Controller를 의존하면 다음과 같은 문제가 생깁니다.
+
+```text
+1. 비즈니스 로직이 웹 계층에 의존하게 된다.
+2. 테스트하기 어려워진다.
+3. 웹 요청이 아닌 다른 방식으로 Service를 재사용하기 어렵다.
+4. 계층 구조가 뒤집힌다.
+```
+
+따라서 Service는 Controller를 몰라야 합니다.
+
+---
+
+## 15. 해결 방향을 한 문장으로 정리하기
+
+순환 참조를 해결할 때는 다음 문장을 기억하면 좋습니다.
+
+```text
+서로를 직접 부르게 하지 말고,
+공통 책임을 분리하거나,
+상위 흐름 조정 객체를 둔다.
+```
+
+즉, 문제 상황은 다음과 같습니다.
+
+```text
+AService ↔ BService
+```
+
+해결 방향은 두 가지가 대표적입니다.
+
+```text
+방법 1:
+AService → CommonPolicy
+BService → CommonPolicy
+```
+
+```text
+방법 2:
+Facade → AService
+Facade → BService
+```
+
+첫 번째 방법은 공통 로직이 섞여 있을 때 좋습니다.
+
+두 번째 방법은 여러 서비스를 묶는 업무 흐름이 필요할 때 좋습니다.
+
+---
+
+## 16. 이번 문서에서 제안하는 체크리스트
+
+Spring Bean 순환 참조 문제를 만났을 때 다음 순서로 확인하면 좋습니다.
+
+```text
+1. 어떤 Bean들이 서로 참조하고 있는지 확인한다.
+2. 두 객체가 정말 서로를 알아야 하는지 확인한다.
+3. 공통으로 필요한 로직이 있는지 확인한다.
+4. 공통 로직은 Policy, Validator, Resolver 등으로 분리한다.
+5. 여러 서비스를 조합하는 흐름이라면 Facade를 둔다.
+6. Controller → Service → Mapper 방향이 깨지지 않았는지 확인한다.
+7. @Lazy나 allow-circular-references는 마지막 수단으로만 고려한다.
+```
+
+이 체크리스트를 따르면 단순히 오류를 없애는 데서 끝나지 않고, 더 유지보수하기 쉬운 구조로 개선할 수 있습니다.
+
+---
+
+## 17. eGovFrame 코드 생성 관점에서의 의미
+
+eGovFrame VSCode Initializr는 사용자가 빠르게 CRUD 코드를 만들 수 있도록 도와주는 도구입니다.
+
+따라서 생성되는 코드나 문서에서 좋은 구조를 안내하는 것이 중요합니다.
+
+사용자는 생성된 코드를 기반으로 기능을 확장합니다.
+
+이때 처음부터 계층 방향과 의존 관계를 명확히 이해하면 나중에 순환 참조나 강한 결합 문제를 줄일 수 있습니다.
+
+이번 문서의 의미는 다음과 같습니다.
+
+```text
+단순히 오류 해결 방법을 알려주는 것이 아니라,
+Spring 기반 코드에서 의존 방향을 어떻게 설계해야 하는지 안내한다.
+```
+
+즉, 이 문서는 eGovFrame 사용자와 기여자가 더 안정적인 Spring 구조를 이해하는 데 도움을 줄 수 있습니다.
+

--- a/topic.md
+++ b/topic.md
@@ -16,7 +16,7 @@
 | romdyfo | [14](https://github.com/kenu/egov-vscode2026/issues/14) | Spring Security와 eGovFrame 권한 관리 시스템 통합 | open |
 | dovob213 | [13](https://github.com/kenu/egov-vscode2026/issues/13) | GitHub Actions를 활용한 Maven 빌드 및 자동 PR 체크 시스템 구축 | open |
 | byeongjuPark | [12](https://github.com/kenu/egov-vscode2026/issues/12) | Spring Boot Extension Pack 200% 활용법: VS Code 필수 확장 프로그램 | open |
-| Rockernun | [11](https://github.com/kenu/egov-vscode2026/issues/11) | Spring Bean 순환 참조(Circular Dependency) 해결 사례 | open |
+| Rockernun | [11](https://github.com/kenu/egov-vscode2026/issues/11) | [Spring Bean 순환 참조(Circular Dependency) 해결 사례](spring-bean-circular-reference.md) | open |
 | JBumLee | [10](https://github.com/kenu/egov-vscode2026/issues/10) | Validation 프레임워크 활용: @Valid와 BindingResult 처리 | open |
 | songhyeongyu | [9](https://github.com/kenu/egov-vscode2026/issues/9) | Java Heap Dump 분석: eGovFrame 애플리케이션 메모리 누수 잡기 | open |
 | nippyclouding | [8](https://github.com/kenu/egov-vscode2026/issues/8) | eGovFrame 표준 프레임워크와 MyBatis/JPA 혼용 전략 | open |


### PR DESCRIPTION
## Summary

Spring Bean 순환 참조가 무엇인지, 왜 문제가 되는지, 그리고 구조적으로 어떻게 해결할 수 있는지 설명하는 발표 자료를 추가했습니다.

## Background

eGovFrame VSCode Initializr는 Controller, Service, ServiceImpl, Mapper 등 Spring 기반 CRUD 코드를 생성합니다.

사용자가 생성된 코드를 확장하는 과정에서 계층 간 의존 방향이 무너지거나 Service 간 양방향 의존이 생기면 Spring Bean 순환 참조 문제가 발생할 수 있습니다.

## Changes

- Spring Bean과 의존성 주입 개념 설명 추가
- 순환 참조 발생 원인과 예시 코드 추가
- 임시 해결 방식 및 좋은 해결 방법 제시

## Expected Effect

eGovFrame 사용자가 생성된 Spring 코드를 확장할 때 순환 참조를 예방하고, 더 유지보수하기 쉬운 구조로 설계하는 데 도움을 줄 수 있습니다.

## Related Issue

Closes #11 